### PR TITLE
Refactor to work primarily with SVG rendering and capturing

### DIFF
--- a/src/example-toolpaths.ts
+++ b/src/example-toolpaths.ts
@@ -1,11 +1,83 @@
 import { Toolpath } from './type-utils.ts';
 
 export type ToolpathName = 'test1' | 'spbTest' | 'ebbSignature' | 'gCodeWave' |
-                           'ebbBox' | 'gears';
+                           'ebbBox' | 'gears' | '10 degrees' | '30 degrees' | 
+                           '60 degrees' | '90 degrees' | '120 degrees' | '150 degrees' |
+                           '180 degrees';
 
 export type ToolpathCollection = Record<ToolpathName, Toolpath>;
 
 export const exampleToolpaths: ToolpathCollection = {
+    '10 degrees': {
+        isa: 'gcode',
+        instructions: [
+        'G0 X0.00 Y0.00',
+        'G1 X100.0 Y100',
+        'G1 X50.0 Y100',
+        'G1 X100 Y108.816'
+        ]
+    },
+
+    '30 degrees': {
+        isa: 'gcode',
+        instructions: [
+            'G0 X0.00 Y0.00',
+            'G1 X100.0 Y100',
+            'G1 X50.0 Y100',
+            'G1 X100 Y128.868'
+        ]
+    },
+
+    '60 degrees': {
+        isa: 'gcode',
+        instructions: [
+            'G0 X0.00 Y0.00',
+            'G1 X100.0 Y100',
+            'G1 X50.0 Y100',
+            'G1 X100 Y186.603'
+        ]
+    },
+
+    '90 degrees': {
+        isa: 'gcode',
+        instructions: [
+            'G0 X0.00 Y0.00',
+            'G1 X100.0 Y100',
+            'G1 X50.0 Y100',
+            'G1 X50.0 Y150'
+        ]
+    },
+
+    '120 degrees': {
+        isa: 'gcode',
+        instructions: [
+            'G0 X0.00 Y0.00',
+            'G1 X25.0 Y100',
+            'G1 X50.0 Y100',
+            'G1 X100 Y186.603'
+        ]
+    },
+
+    '150 degrees': {
+        isa: 'gcode',
+        instructions: [
+            'G0 X0.00 Y0.00',
+            'G1 X25.0 Y100',
+            'G1 X50.0 Y100',
+            'G1 X100 Y128.868'
+        ]
+    },
+
+    '180 degrees': {
+        isa: 'gcode',
+        instructions: [
+            'G0 X0.00 Y0.00',
+            'G1 X100.0 Y100',
+            'G1 X50.0 Y100',
+            'G1 X25.0 Y100'
+        ]
+    },
+
      'test1': {
          isa: 'gcode',
          instructions : [

--- a/src/overlay-functions.ts
+++ b/src/overlay-functions.ts
@@ -1,8 +1,8 @@
 import * as THREE from 'three';
-import { FontLoader } from 'three/addons/loaders/FontLoader.js';
-import { TextGeometry } from 'three/addons/geometries/TextGeometry.js';
+//import { FontLoader } from 'three/addons/loaders/FontLoader.js';
+//import { TextGeometry } from 'three/addons/geometries/TextGeometry.js';
 
-import { getVisualizationSpaceInstance } from './visualization-space-instance';
+//import { getVisualizationSpaceInstance } from './visualization-space-instance';
 
 // function draws a crosshair at the given x and y coord
 export function drawCross(x: number, y: number) {
@@ -43,22 +43,43 @@ export function drawArrow(x1: number, y1: number, x2: number, y2: number) {
     return group;
 }
 
+/*
 // function draws text on the bed starting at the given x and y coord
 // containing the given input string
 export function drawTextAt(x: number, y: number, input: string) {
     let group = new THREE.Group();
     const loader = new FontLoader();
-
+    
     return new Promise<THREE.Group>((resolve) => {
         loader.load('fonts.json', function (font) {
+            
             let text = new TextGeometry(input, {
                 font: font as any,
-                size: 8,
+                size: 5,
                 height: 0.02,
             });
     
-            let material = new THREE.MeshPhongMaterial( {color: 0xffb6c1} );
+            let material = new THREE.MeshBasicMaterial( {color: 0xffb6c1} );
             let textMesh = new THREE.Mesh(text, material);
+            textMesh.position.set(y, -x, 0);
+            textMesh.rotation.z =  - Math.PI / 2;
+            group.add(textMesh);
+            group.rotateX(Math.PI / 2);
+            group.rotateZ(Math.PI / 2);
+            
+            
+            const textOptions = {
+                font: font,
+                size: 8,
+                height: 0.001,
+                curveSegments: 12,
+                bevelEnabled: false
+            };
+    
+            const shapes = font.generateShapes(input, textOptions.size);
+            const geometry = new THREE.ShapeGeometry(shapes);
+            const material = new THREE.MeshBasicMaterial({ color: 0xffb6c1 });
+            const textMesh = new THREE.Mesh(geometry, material);
             textMesh.position.set(y, -x, 0);
             textMesh.rotation.z =  - Math.PI / 2;
             group.add(textMesh);
@@ -68,7 +89,7 @@ export function drawTextAt(x: number, y: number, input: string) {
     
         resolve(group);
     });
-}
+}*/
 
 // draws a highlighted rectangle given the width, height, and left end-point
 export function drawRect(width: number, height: number, x: number, y: number) {
@@ -88,7 +109,7 @@ export function drawRect(width: number, height: number, x: number, y: number) {
     group.rotateX(Math.PI / 2);
     return group;
 }
-
+/*
 // given a reference to an object, removes it from the scene and re-renders
 export function removeMark(objectToRemove: THREE.Object3D) {
     let visualizationSpace = getVisualizationSpaceInstance();
@@ -101,4 +122,4 @@ export function removeMark(objectToRemove: THREE.Object3D) {
 // clones an existing THREE.Group
 export function deepClone(object: any) {
     return JSON.parse(JSON.stringify(object));
-}
+}*/

--- a/src/overlay-functions.ts
+++ b/src/overlay-functions.ts
@@ -49,23 +49,25 @@ export function drawTextAt(x: number, y: number, input: string) {
     let group = new THREE.Group();
     const loader = new FontLoader();
 
-    loader.load('fonts.json', function (font) {
-        let text = new TextGeometry(input, {
-            font: font,
-            size: 8,
-            height: 0.02,
+    return new Promise<THREE.Group>((resolve) => {
+        loader.load('fonts.json', function (font) {
+            let text = new TextGeometry(input, {
+                font: font as any,
+                size: 8,
+                height: 0.02,
+            });
+    
+            let material = new THREE.MeshPhongMaterial( {color: 0xffb6c1} );
+            let textMesh = new THREE.Mesh(text, material);
+            textMesh.position.set(y, -x, 0);
+            textMesh.rotation.z =  - Math.PI / 2;
+            group.add(textMesh);
+            group.rotateX(Math.PI / 2);
+            group.rotateZ(Math.PI / 2);
         });
-
-        let material = new THREE.MeshPhongMaterial( {color: 0xffb6c1} );
-        let textMesh = new THREE.Mesh(text, material);
-        textMesh.position.set(y, -x, 0);
-        textMesh.rotation.z =  - Math.PI / 2;
-        group.add(textMesh);
-        group.rotateX(Math.PI / 2);
-        group.rotateZ(Math.PI / 2);
+    
+        resolve(group);
     });
-
-    return group;
 }
 
 // draws a highlighted rectangle given the width, height, and left end-point

--- a/src/overlay-functions.ts
+++ b/src/overlay-functions.ts
@@ -68,15 +68,7 @@ export function drawTextAt(x: number, y: number, input: string) {
     return group;
 }
 
-// given a reference to an object, removes it from the scene and re-renders
-export function removeMark(objectToRemove: THREE.Object3D) {
-    let visualizationSpace = getVisualizationSpaceInstance();
-    if (visualizationSpace) {
-        visualizationSpace.removeMark(objectToRemove);
-        visualizationSpace.requestRenderScene();
-    }
-}
-
+// draws a highlighted rectangle given the width, height, and left end-point
 export function drawRect(width: number, height: number, x: number, y: number) {
     let geometry = new THREE.PlaneGeometry(width, height);
     let material = new THREE.MeshBasicMaterial({
@@ -93,4 +85,18 @@ export function drawRect(width: number, height: number, x: number, y: number) {
     group.add(rectangle);
     group.rotateX(Math.PI / 2);
     return group;
+}
+
+// given a reference to an object, removes it from the scene and re-renders
+export function removeMark(objectToRemove: THREE.Object3D) {
+    let visualizationSpace = getVisualizationSpaceInstance();
+    if (visualizationSpace) {
+        visualizationSpace.removeMark(objectToRemove);
+        visualizationSpace.requestRenderScene();
+    }
+}
+
+// clones an existing THREE.Group
+export function deepClone(object: any) {
+    return JSON.parse(JSON.stringify(object));
 }

--- a/src/overlay.ts
+++ b/src/overlay.ts
@@ -25,10 +25,13 @@ function basicOverlay() {
     // STEP 1
     let group1 = new THREE.Group();
     let stock = drawRect(80, 30, 50, 50);
-    let text = drawTextAt(100, 10, "Place stock here")
+    // let text = drawTextAt(100, 10, "Place stock here");
+    drawTextAt(100, 10, "Place stock here").then((text) => {
+        group1.add(text);
+    });
     let arrow = drawArrow(95, 10, 75, 45);
     group1.add(stock);
-    group1.add(text);
+    //group1.add(text);
     group1.add(arrow);
 
     let step1 = step("Placing the stock material", group1);
@@ -36,8 +39,11 @@ function basicOverlay() {
 
     // STEP 2
     let group2 = new THREE.Group();
-    let text1 = drawTextAt(100, 50, "center XY");
-    group2.add(text1);
+    //let text1 = drawTextAt(100, 50, "center XY");
+    drawTextAt(100, 50, "center XY").then((text2) => {
+        group2.add(text2);
+    })
+    //group2.add(text1);
 
     let step2 = step("Center x and y", group2);
     steps.push(step2);
@@ -45,9 +51,12 @@ function basicOverlay() {
     // STEP 3
     let group3 = new THREE.Group();
     let cross = drawCross(50, 50);
-    let text2 = drawTextAt(100, 80, "Confirm?");
+    //let text2 = drawTextAt(100, 80, "Confirm?");
+    drawTextAt(100, 80, "Confirm?").then((text3) => {
+        group3.add(text3);
+    })
     group3.add(cross);
-    group3.add(text2);
+    //group3.add(text2);
 
     let step3 = step("Confirm crosshair", group3);
     steps.push(step3);

--- a/src/overlay.ts
+++ b/src/overlay.ts
@@ -1,7 +1,7 @@
 import * as THREE from 'three';
 
 import { STEP } from './type-utils.ts';
-import { drawCross, drawArrow, drawTextAt, drawRect } from './overlay-functions.ts';
+import { drawCross, drawArrow, drawRect } from './overlay-functions.ts';
 
 export type Overlay = () => STEP[];
 export type OverlayName = 'basicOverlay';
@@ -12,10 +12,16 @@ export const overlayCollection: OverlayCollection = {
     basicOverlay: basicOverlay
 };
 
-export function step(stepName: string, visGroup: THREE.Group) {
+export function step(stepName: string, visGroup: THREE.Group, 
+                     dispText: string, xPos: string, yPos: string) {
     return {
-        label: stepName,
-        group: visGroup
+        label: stepName, 
+        group: visGroup,
+        text: {
+            chars: dispText,
+            x: xPos,
+            y: yPos
+        }
     }
 }
 
@@ -25,40 +31,44 @@ function basicOverlay() {
     // STEP 1
     let group1 = new THREE.Group();
     let stock = drawRect(80, 30, 50, 50);
+    /*
     // let text = drawTextAt(100, 10, "Place stock here");
     drawTextAt(100, 10, "Place stock here").then((text) => {
         group1.add(text);
-    });
+    });*/
     let arrow = drawArrow(95, 10, 75, 45);
     group1.add(stock);
     //group1.add(text);
     group1.add(arrow);
 
-    let step1 = step("Placing the stock material", group1);
+    let step1 = step("Placing the stock material", group1, "Place stock here",
+                     '-110', '230');
     steps.push(step1);
 
     // STEP 2
     let group2 = new THREE.Group();
     //let text1 = drawTextAt(100, 50, "center XY");
+    /*
     drawTextAt(100, 50, "center XY").then((text2) => {
         group2.add(text2);
     })
     //group2.add(text1);
-
-    let step2 = step("Center x and y", group2);
+    */
+    let step2 = step("Center x and y", group2, "center XY", '0', '0');
     steps.push(step2);
 
     // STEP 3
     let group3 = new THREE.Group();
     let cross = drawCross(50, 50);
     //let text2 = drawTextAt(100, 80, "Confirm?");
+    /*
     drawTextAt(100, 80, "Confirm?").then((text3) => {
         group3.add(text3);
-    })
+    })*/
     group3.add(cross);
     //group3.add(text2);
 
-    let step3 = step("Confirm crosshair", group3);
+    let step3 = step("Confirm crosshair", group3, "confirm?", '0', '0');
     steps.push(step3);
 
     return steps;

--- a/src/overlay.ts
+++ b/src/overlay.ts
@@ -1,36 +1,56 @@
 import * as THREE from 'three';
 
-import { drawCross, drawArrow, drawTextAt, removeMark, drawRect } from './overlay-functions.ts';
+import { STEP } from './type-utils.ts';
+import { drawCross, drawArrow, drawTextAt, drawRect } from './overlay-functions.ts';
 
-// clones an existing THREE.Group
-function deepClone(object: any) {
-    return JSON.parse(JSON.stringify(object));
+export type Overlay = () => STEP[];
+export type OverlayName = 'basicOverlay';
+
+export type OverlayCollection = Record<OverlayName, Overlay>;
+
+export const overlayCollection: OverlayCollection = {
+    basicOverlay: basicOverlay
+};
+
+export function step(stepName: string, visGroup: THREE.Group) {
+    return {
+        label: stepName,
+        group: visGroup
+    }
 }
 
-export function overlay1() {
-    let groupList:THREE.Group[] = [];
+function basicOverlay() {
+    let steps: STEP[] = [];
+    
+    // STEP 1
     let group1 = new THREE.Group();
     let stock = drawRect(80, 30, 50, 50);
-    group1.add(stock);
-
     let text = drawTextAt(100, 10, "Place stock here")
-    group1.add(text);
-
     let arrow = drawArrow(95, 10, 75, 45);
+    group1.add(stock);
+    group1.add(text);
     group1.add(arrow);
-    groupList.push(group1);
 
+    let step1 = step("Placing the stock material", group1);
+    steps.push(step1);
+
+    // STEP 2
     let group2 = new THREE.Group();
     let text1 = drawTextAt(100, 50, "center XY");
     group2.add(text1);
-    groupList.push(group2);
 
+    let step2 = step("Center x and y", group2);
+    steps.push(step2);
+
+    // STEP 3
     let group3 = new THREE.Group();
     let cross = drawCross(50, 50);
     let text2 = drawTextAt(100, 80, "Confirm?");
     group3.add(cross);
     group3.add(text2);
-    groupList.push(group3);
 
-    return groupList;
+    let step3 = step("Confirm crosshair", group3);
+    steps.push(step3);
+
+    return steps;
 }

--- a/src/root-element.ts
+++ b/src/root-element.ts
@@ -182,6 +182,7 @@ export class RootElement extends LitElement {
         }
     }
 
+    
     maybeHighlightToolpath(name: ToolpathName) {
         return name === this.currentToolpathName ? 'highlight' : '';
     }
@@ -189,6 +190,7 @@ export class RootElement extends LitElement {
     maybeHighlightTSS(name: TSSName) {
         return name === this.currentTSSName ? 'highlight' : '';
     }
+    
 
     maybeHighlightOverlay(name: OverlayName) {
         return name === this.currentOverlayName ? 'highlight' : '';
@@ -198,6 +200,7 @@ export class RootElement extends LitElement {
         return html`
             <div class="container">
                 <div class="menu-col">
+                <!-- REMOVE
                     <div class="menu">
                         <div class="menu-head">Toolpath Menu</div>
                         <ul class="list">
@@ -227,6 +230,8 @@ export class RootElement extends LitElement {
                             })}
                         </ul>
                     </div>
+                -->
+
                     <div class="menu">
                         <div class="menu-head">Overlay Menu</div>
                         <ul class="list">
@@ -342,6 +347,7 @@ export class RootElement extends LitElement {
         }
         .visualization-pane-col {
             margin: 5px;
+            border: 1px solid white;
         }
         .image-with-border {
             border: 1px solid white;

--- a/src/root-element.ts
+++ b/src/root-element.ts
@@ -1,7 +1,7 @@
 import { LitElement, css, html } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
-import { Toolpath, Renderer } from './type-utils.ts';
+import { Toolpath } from './type-utils.ts';
 import { exampleToolpaths, ToolpathName } from './example-toolpaths.ts';
 import { tssCollection, TSSName, TSS } from './tss.ts';
 import { VisualizationSpace } from './visualization-space.ts';
@@ -27,9 +27,6 @@ export class RootElement extends LitElement {
     @property()
     currentTSS: TSS = tssCollection[this.currentTSSName];
 
-    @property()
-    currentRenderer: Renderer = 'svg';
-
     onToolpathClick(newName: ToolpathName) {
         if (this.currentToolpathName !== newName) {
             this.currentToolpathName = newName;
@@ -44,17 +41,6 @@ export class RootElement extends LitElement {
             this.currentTSS = tssCollection[newName];
         };
         this.renderTSS();
-    }
-
-    // function to change renderers from SVG to WebGL
-    onRendererChange(rendererType: Renderer) {
-        this.visualizationSpace?.initThreeRenderer(rendererType);
-        this.visualizationSpace?.initPostDomLoadLogistics();
-        // if (rendererType === 'svg') {
-        //     //this.visualizationSpace?.computeOverheadView();
-        // } else if (rendererType === 'webgl') {
-        //     //this.visualizationSpace?.initCamera(new Vector3(150, 17/2, 109), true);
-        // }
     }
 
     // positions the camera to overhead view

--- a/src/root-element.ts
+++ b/src/root-element.ts
@@ -129,11 +129,18 @@ export class RootElement extends LitElement {
         svgCopy.addEventListener('click', () => {
             this.handleImageInteraction(svgCopy.outerHTML);
         })
+
         let cameraRollContainer = this.renderRoot.querySelector('#camera-roll-container');
         cameraRollContainer?.appendChild(svgCopy);
         console.log(svgElement);
+       
+        svgCopy.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
+        svgCopy.setAttribute('xmlns:xlink', 'http://www.w3.org/1999/xlink');
+        svgCopy.innerHTML = svgElement.innerHTML;
 
-        let svgText = svgCopy.outerHTML;
+
+        let serializer = new XMLSerializer();
+        let svgText = serializer.serializeToString(svgCopy);
         await fetch(url, {
             method: 'PUT',
             body: svgText
@@ -186,6 +193,18 @@ export class RootElement extends LitElement {
             if (this.visualizationSpace) {
                 this.visualizationSpace.removeAllViz();
                 this.visualizationSpace.addVizWithName(myViz, this.currentOverlayName);
+
+                // add text
+                let svgElement = this.renderRoot.querySelector('#canvas-container svg') as SVGElement;
+                const svgText = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+                const displayText = this.currentOverlay()[this.currentStepNum].text;
+                // Set the attributes of the SVG text element
+                svgText.setAttribute('x', displayText.x);
+                svgText.setAttribute('y', displayText.y);
+                svgText.setAttribute('fill', 'pink');
+                svgText.setAttribute('font-size', '30px');
+                svgText.textContent = displayText.chars;
+                svgElement.appendChild(svgText);
             }
         }
     }

--- a/src/root-element.ts
+++ b/src/root-element.ts
@@ -121,7 +121,9 @@ export class RootElement extends LitElement {
     }
 
     // takes picture of the current visualization space
-    onSnapshotClickSvg() {
+    async onSnapshotClickSvg() {
+        const url = 'http://localhost:3000/overlay/latestSvg';
+
         let svgElement = this.renderRoot.querySelector('#canvas-container svg') as SVGElement;
         let svgCopy = svgElement.cloneNode(true) as SVGElement;
         svgCopy.addEventListener('click', () => {
@@ -130,6 +132,12 @@ export class RootElement extends LitElement {
         let cameraRollContainer = this.renderRoot.querySelector('#camera-roll-container');
         cameraRollContainer?.appendChild(svgCopy);
         console.log(svgElement);
+
+        let svgText = svgCopy.outerHTML;
+        await fetch(url, {
+            method: 'PUT',
+            body: svgText
+        });
     }
 
     // downloads images upon user clicking on them

--- a/src/root-element.ts
+++ b/src/root-element.ts
@@ -102,6 +102,24 @@ export class RootElement extends LitElement {
         }
     }
 
+    // handles iterating to the previous step of the overlay
+    onPrevStep() {
+        if (this.currentOverlay) {
+            if (this.currentStepNum >= 1) {
+                this.currentStepNum--;
+                this.renderOverlay();
+            }
+        }
+    }
+
+    // handles resetting the overlay to start from first step again
+    onResetSteps() {
+        if (this.currentOverlay) {
+            this.currentStepNum = 0;
+            this.renderOverlay();
+        }
+    }
+
     // takes picture of the current visualization space
     onSnapshotClickSvg() {
         let svgElement = this.renderRoot.querySelector('#canvas-container svg') as SVGElement;
@@ -220,10 +238,18 @@ export class RootElement extends LitElement {
                                 `;
                             })}
                         </ul>
-                        <div class="menu-head">Next Step</div>
+                        <div class="menu-head">Step Menu</div>
+                        <label>
+                            <input type="button" name="Previous Step" value="Prev Step"
+                            @click=${() => this.onPrevStep()}>
+                        </label>
                         <label>
                             <input type="button" name="Next Step" value="Next Step"
                             @click=${() => this.onNextStep()}>
+                        </label>
+                        <label>
+                            <input type="button" name="First Step" value="First Step"
+                            @click=${() => this.onResetSteps()}>
                         </label>
                         <div class="menu-head">Step Description</div>
                         <div class="steps-box"> <code>${this.currentStepName}</code></div>

--- a/src/root-element.ts
+++ b/src/root-element.ts
@@ -90,7 +90,8 @@ export class RootElement extends LitElement {
     onPositionImage() {
         this.visualizationSpace?.computeOverheadView();
     }
-
+     
+    /*
     // handles iterating through the different steps of the overlays
     onNextStep() {
         if (this.currentOverlay) {
@@ -119,7 +120,9 @@ export class RootElement extends LitElement {
             this.renderOverlay();
         }
     }
+    */
 
+    /*
     // takes picture of the current visualization space
     async onSnapshotClickSvg() {
         const url = 'http://localhost:3000/overlay/latestSvg';
@@ -156,6 +159,7 @@ export class RootElement extends LitElement {
         link.download = 'snapshot.svg';
         link.click();
     }
+    */
 
     // renders the toolpaths based on selected TSS function
     renderTSS() {
@@ -227,7 +231,6 @@ export class RootElement extends LitElement {
         return html`
             <div class="container">
                 <div class="menu-col">
-                <!-- REMOVE
                     <div class="menu">
                         <div class="menu-head">Toolpath Menu</div>
                         <ul class="list">
@@ -257,8 +260,8 @@ export class RootElement extends LitElement {
                             })}
                         </ul>
                     </div>
-                -->
 
+                    <!-- REMOVE
                     <div class="menu">
                         <div class="menu-head">Overlay Menu</div>
                         <ul class="list">
@@ -273,19 +276,20 @@ export class RootElement extends LitElement {
                         <div class="menu-head">Step Menu</div>
                         <label>
                             <input type="button" name="Previous Step" value="Prev Step"
-                            @click=${() => this.onPrevStep()}>
+                            @click=>
                         </label>
                         <label>
                             <input type="button" name="Next Step" value="Next Step"
-                            @click=${() => this.onNextStep()}>
+                            @click=>
                         </label>
                         <label>
                             <input type="button" name="First Step" value="First Step"
-                            @click=${() => this.onResetSteps()}>
+                            @click=>
                         </label>
                         <div class="menu-head">Step Description</div>
                         <div class="steps-box"> <code>${this.currentStepName}</code></div>
                     </div>
+                    -->
 
                     <div class="menu">
                         <div class="menu-head">Position Image</div>
@@ -295,18 +299,22 @@ export class RootElement extends LitElement {
                         </label>
                     </div>
 
+                    <!-- REMOVE       
                     <div class="menu">
                         <div class="menu-head">Capture Image</div>
                         <label>
                             <input type="button" name="Capture Image" value="Take snapshot"
-                            @click=${() => this.onSnapshotClickSvg()}>
+                            @click=>
                         </label>
                     </div>
+                    -->
                         
                 </div>
                 <div class="visualization-pane-col">
                     <div id="canvas-container"></div>
+                    <!-- REMOVE
                     <div id="camera-roll-container"></div>
+                    -->
                 </div>
                 <!-- <debugging-pane></debugging-pane> -->
             </div>
@@ -392,6 +400,7 @@ export class RootElement extends LitElement {
         #canvas-container canvas {
             border: 1px solid white;
         }
+        <!-- REMOVE
         #camera-roll-container {
             max-width: 750px;
             height: 200px;
@@ -404,6 +413,7 @@ export class RootElement extends LitElement {
             max-width: 150px;
             margin-right: 5px;
         }
+        -->
     `;
 }
 

--- a/src/tss.ts
+++ b/src/tss.ts
@@ -3,26 +3,27 @@ import * as THREE from 'three';
 import { IR } from './type-utils.ts';
 
 /* Imports for efficient line rendering. */
-import { Line2 } from 'three/examples/jsm/lines/Line2.js'
-import { LineGeometry } from 'three/examples/jsm/lines/LineGeometry.js'
-import { LineMaterial } from 'three/examples/jsm/lines/LineMaterial.js'
+//import { Line2 } from 'three/examples/jsm/lines/Line2.js'
+//import { LineGeometry } from 'three/examples/jsm/lines/LineGeometry.js'
+//import { LineMaterial } from 'three/examples/jsm/lines/LineMaterial.js'
 //import { LineSegments2 } from 'three/examples/jsm/lines/LineSegments2.js'
 //import { LineSegmentsGeometry } from 'three/examples/jsm/lines/LineSegmentsGeometry.js'
 
 export type TSS = (tp: IR[]) => THREE.Group;
-export type TSSName = 'basicVis' | 'distanceTraveledVis';
+export type TSSName = 'basicVis' | 'distanceTraveledVis' | 'sharpAnglesVis';
 
 export type TSSCollection = Record<TSSName, TSS>
 
 export const tssCollection: TSSCollection = {
   basicVis: basicVis,
-  distanceTraveledVis: distanceTraveledVis
+  distanceTraveledVis: distanceTraveledVis,
+  sharpAnglesVis: sharpAnglesVis
 };
 
 function basicVis(irs: IR[]) {
-  //let moveCurves: THREE.LineCurve3[] = [];
-  let positions: THREE.Vector3[] = [];
-  let colors: number[] = [];
+  let moveCurves: THREE.LineCurve3[] = [];
+  //let positions: THREE.Vector3[] = [];
+  //let colors: number[] = [];
   let currentPos = new THREE.Vector3();
   let previousPos = new THREE.Vector3();
   let isOnBed = false;
@@ -36,11 +37,11 @@ function basicVis(irs: IR[]) {
 
     if (isOnBed && ir.state.toolOnBed) {
       if (currentPos.distanceTo(previousPos) > Number.EPSILON) {
-        //let moveCurve = new THREE.LineCurve3(currentPos, newPos);
-        //moveCurves.push(moveCurve);
-        positions.push(newPos);
-        let red = [255, 0, 0];
-        colors.push(...red);
+        let moveCurve = new THREE.LineCurve3(currentPos, newPos);
+        moveCurves.push(moveCurve);
+        //positions.push(newPos);
+        //let red = [255, 0, 0];
+        //colors.push(...red);
       }
     }
     // starts new line segment when transitioning from on and off bed
@@ -53,13 +54,14 @@ function basicVis(irs: IR[]) {
     currentPos = newPos;
   });
 
-  /*
+  
   let lines = moveCurves.map(curve => {
-    let geometry = new LineGeometry().setFromPoints(curve.getPoints(50));
-    let material = new LineMaterial({ color: 0xff0000 });
-    return new Line2(geometry, material);
-  });*/
-
+    let geometry = new THREE.BufferGeometry().setFromPoints(curve.getPoints(50));
+    let material = new THREE.LineBasicMaterial({ color: 0xff0000 });
+    return new THREE.Line(geometry, material);
+  });
+  
+  /*
   let positionsFlat = positions.map((vec) => [vec.x, vec.y, vec.z]).flat();
   let lineGeom = new LineGeometry();
   lineGeom.setPositions(positionsFlat);
@@ -75,13 +77,15 @@ function basicVis(irs: IR[]) {
   }
   //line.scale.set(1, 1, 1);
   line.computeLineDistances();
+  */
+
   let group = new THREE.Group();
-  /*
+  
   lines.forEach(line => group.add(line));
   if (irs[0].state.units === 'in') {
     group.scale.set(25.4, 25.4, 25.4); // in to mm converstion
-  }*/
-  group.add(line);
+  }
+  //group.add(line);
   group.rotateX(Math.PI / 2);
   return group;
 }
@@ -156,3 +160,102 @@ function distanceTraveledVis(irs: IR[]) {
   }
   return group;
 }
+
+function sharpAnglesVis(irs: IR[], sharpAngleThreshold: number = 60) {
+  let moveCurves: THREE.LineCurve3[] = [];
+  let currentPos = new THREE.Vector3();
+  let previousPos = new THREE.Vector3();
+  let isOnBed = false;
+
+  irs.forEach(function (ir) {
+    let newPos = new THREE.Vector3(
+      ir.args.x || currentPos.x,
+      ir.args.y || currentPos.y,
+      ir.args.z || currentPos.z
+    );
+
+    if (isOnBed && ir.state.toolOnBed) {
+      if (currentPos.distanceTo(previousPos) > Number.EPSILON) {
+        let moveCurve = new THREE.LineCurve3(currentPos, newPos);
+        moveCurves.push(moveCurve);
+      }
+    }
+    // starts new line segment when transitioning from on and off bed
+    if (!isOnBed && ir.state.toolOnBed) {
+      currentPos = newPos;
+    }
+
+    isOnBed = ir.state.toolOnBed || false;
+    previousPos = currentPos;
+    currentPos = newPos;
+  });
+
+  let lines = moveCurves.map(curve => {
+    let geometry = new THREE.BufferGeometry().setFromPoints(curve.getPoints(50));
+    let material = new THREE.LineBasicMaterial({ color: 0xff0000 });
+    return new THREE.Line(geometry, material);
+  });
+  console.log(moveCurves);
+
+  let sharpAngles = [];
+  // now, find all the sharp angles based on some threshold value
+  for (let i = 0; i < moveCurves.length - 1; i++) {
+    // current and next curves
+    let curve1 = moveCurves[i];
+    let curve2 = moveCurves[i + 1];
+
+    // end points of the curves
+    let endPoint1 = curve1.v2.clone();
+    let endPoint2 = curve2.v1.clone();
+
+    // Calculate the vectors representing the directions of the curves
+    let dir1 = endPoint1.clone().sub(curve1.v1);
+    let dir2 = endPoint2.clone().sub(curve2.v2);
+
+    // Normalize the vectors
+    dir1.normalize();
+    dir2.normalize();
+
+    // Calculate the angle between the vectors in degrees
+    let angle = THREE.MathUtils.radToDeg(dir1.angleTo(dir2));
+    console.log(angle);
+    // Check if the angle is sharper than threshold
+    if (angle < sharpAngleThreshold) {
+      // Define the scale factor for the shorter line
+      let scaleFactor = 0.25; // Adjust as needed
+
+      // Calculate the new endpoint for the shorter line
+      let shorterLineEnd = new THREE.Vector3().copy(curve1.v1).addScaledVector(dir1, curve1.v2.distanceTo(curve1.v1) * scaleFactor);
+
+      // Create a new line with the same direction but a different length
+      let shorterLine = new THREE.Line(new THREE.BufferGeometry().setFromPoints([curve1.v2, shorterLineEnd]), new THREE.LineBasicMaterial({ color: 0x00ff00 }));
+
+      // Add the green line to the array
+      sharpAngles.push(shorterLine);
+
+      // Calculate the new endpoint for the shorter line
+      let shorterLineEnd2 = new THREE.Vector3().copy(curve2.v2).addScaledVector(dir2, curve2.v2.distanceTo(curve2.v1) * scaleFactor);
+
+      // Create a new line with the same direction but a different length
+      let shorterLine2 = new THREE.Line(new THREE.BufferGeometry().setFromPoints([curve2.v1, shorterLineEnd2]), new THREE.LineBasicMaterial({ color: 0x00ff00 }));
+
+      // Add the green line to the array
+      sharpAngles.push(shorterLine2);
+    }
+  }
+  
+  let group = new THREE.Group();
+  
+  lines.forEach(line => group.add(line));
+  sharpAngles.forEach(line => group.add(line));
+  if (irs[0].state.units === 'in') {
+    group.scale.set(25.4, 25.4, 25.4); // in to mm converstion
+  }
+  group.rotateX(Math.PI / 2);
+  return group;
+}
+
+
+
+
+

--- a/src/tss.ts
+++ b/src/tss.ts
@@ -195,7 +195,6 @@ function sharpAnglesVis(irs: IR[], sharpAngleThreshold: number = 60) {
     let material = new THREE.LineBasicMaterial({ color: 0xff0000 });
     return new THREE.Line(geometry, material);
   });
-  console.log(moveCurves);
 
   let sharpAngles = [];
   // now, find all the sharp angles based on some threshold value
@@ -218,7 +217,7 @@ function sharpAnglesVis(irs: IR[], sharpAngleThreshold: number = 60) {
 
     // Calculate the angle between the vectors in degrees
     let angle = THREE.MathUtils.radToDeg(dir1.angleTo(dir2));
-    console.log(angle);
+   
     // Check if the angle is sharper than threshold
     if (angle < sharpAngleThreshold) {
       // Define the scale factor for the shorter line
@@ -247,6 +246,7 @@ function sharpAnglesVis(irs: IR[], sharpAngleThreshold: number = 60) {
   let group = new THREE.Group();
   
   lines.forEach(line => group.add(line));
+  // add all the sharp angles to the group
   sharpAngles.forEach(line => group.add(line));
   if (irs[0].state.units === 'in') {
     group.scale.set(25.4, 25.4, 25.4); // in to mm converstion

--- a/src/tss.ts
+++ b/src/tss.ts
@@ -4,6 +4,13 @@ import { IR } from './type-utils.ts';
 import { drawCross, drawArrow, drawTextAt, removeMark, drawRect } from './overlay-functions.ts';
 import { overlay1 } from './overlay.ts';
 
+/* Imports for efficient line rendering. */
+import { Line2 } from 'three/examples/jsm/lines/Line2.js'
+import { LineGeometry } from 'three/examples/jsm/lines/LineGeometry.js'
+import { LineMaterial } from 'three/examples/jsm/lines/LineMaterial.js'
+import { LineSegments2 } from 'three/examples/jsm/lines/LineSegments2.js'
+import { LineSegmentsGeometry } from 'three/examples/jsm/lines/LineSegmentsGeometry.js'
+
 export type TSS = (tp: IR[]) => THREE.Group;
 export type TSSName = 'basicVis' | 'distanceTraveledVis' | 'overlay';
 

--- a/src/type-utils.ts
+++ b/src/type-utils.ts
@@ -3,7 +3,6 @@ export type GCode = "gcode";
 export type SBP = "sbp";
 export type ISA = EBB | GCode | SBP;
 export type Instruction = string;
-export type Renderer = "svg" | "webgl";
 
 export interface Toolpath {
     isa: ISA;

--- a/src/type-utils.ts
+++ b/src/type-utils.ts
@@ -24,3 +24,8 @@ export interface IR {
     }
 };
 
+export interface STEP {
+    label: string;
+    group: THREE.Group;
+}
+

--- a/src/type-utils.ts
+++ b/src/type-utils.ts
@@ -27,5 +27,10 @@ export interface IR {
 export interface STEP {
     label: string;
     group: THREE.Group;
+    text: {
+        chars: string;
+        x: string;
+        y: string;
+    }
 }
 

--- a/src/visualization-space.ts
+++ b/src/visualization-space.ts
@@ -120,6 +120,22 @@ export class VisualizationSpace {
             camera.position.set(-500, 500, 500);
             camera.updateProjectionMatrix();
         }
+        // set default to be overhead view
+        if (camera instanceof THREE.PerspectiveCamera) {
+            const perspectiveCamera = camera as THREE.PerspectiveCamera;
+            perspectiveCamera.position.set(0, -1000, 0);
+            perspectiveCamera.lookAt(this.scene.position.add(new THREE.Vector3(-150, 0, -109)));
+            perspectiveCamera.up.set(0, 1, 0);
+            perspectiveCamera.fov = 4.5;
+            perspectiveCamera.updateProjectionMatrix();
+        } else if (camera instanceof THREE.OrthographicCamera) {
+            const orthographicCamera = camera as THREE.OrthographicCamera;
+            orthographicCamera.position.set(0, -1000, 0);
+            orthographicCamera.lookAt(this.scene.position.add(new THREE.Vector3(-150, 0, -109)));
+            orthographicCamera.up.set(0, 1, 0);
+            orthographicCamera.zoom = 2.2;
+            orthographicCamera.updateProjectionMatrix();
+        }
         return camera;
     }
 

--- a/src/visualization-space.ts
+++ b/src/visualization-space.ts
@@ -1,7 +1,8 @@
 import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 //import { cameraProjectionMatrix } from 'three/examples/jsm/nodes/Nodes.js';
-// import { SVGRenderer } from 'three/addons/renderers/SVGRenderer.js';
+import { SVGRenderer } from 'three/addons/renderers/SVGRenderer.js';
+import { Renderer } from './type-utils.ts'
 
 export class VisualizationSpace {
     protected domContainer: HTMLDivElement;
@@ -63,7 +64,7 @@ export class VisualizationSpace {
     }
 
     initPostDomLoadLogistics() {
-        this.threeRenderer = this.initThreeRenderer();
+        this.threeRenderer = this.initThreeRenderer('svg');
         this.controls = this.initControls(this.camera, this.threeRenderer);
         this.threeRenderScene();
         // let animate = () => {
@@ -134,8 +135,8 @@ export class VisualizationSpace {
     }
 
     initThreeRenderer() {
-        let renderer = new THREE.WebGLRenderer({ antialias: true });
-        renderer.setPixelRatio(window.devicePixelRatio);
+        let renderer = new SVGRenderer();
+        (renderer as THREE.WebGLRenderer).setPixelRatio(window.devicePixelRatio);
         renderer.setSize(720, 480);
         this.domContainer.appendChild(renderer.domElement);
         return renderer;

--- a/src/visualization-space.ts
+++ b/src/visualization-space.ts
@@ -1,14 +1,14 @@
 import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 //import { cameraProjectionMatrix } from 'three/examples/jsm/nodes/Nodes.js';
-import { SVGRenderer } from 'three/addons/renderers/SVGRenderer.js';
+import { SVGRenderer } from 'three/examples/jsm/renderers/SVGRenderer.js';
 
 export class VisualizationSpace {
     protected domContainer: HTMLDivElement;
     protected scene: THREE.Scene;
     protected camera: THREE.Camera;
     protected controls?: OrbitControls;
-    protected threeRenderer: SVGRenderer;
+    protected threeRenderer: SVGRenderer
     protected envelopeGroup: THREE.Group;
     protected vizGroup: THREE.Group;
     protected renderRequested: boolean; 
@@ -21,8 +21,8 @@ export class VisualizationSpace {
         this.scene.add(this.envelopeGroup);
         this.scene.add(this.vizGroup);
         this.camera = this.initCamera(this.envelopeGroup.position, true);
-        this.renderRequested = false;
         this.threeRenderer = this.initThreeRenderer();
+        this.renderRequested = false;
         this.initPostDomLoadLogistics();
         // For debugging
         (window as any).vs = this;
@@ -64,6 +64,7 @@ export class VisualizationSpace {
     }
 
     initPostDomLoadLogistics() {
+        //this.threeRenderer = this.initThreeRenderer();
         this.controls = this.initControls(this.camera, this.threeRenderer);
         this.threeRenderScene();
         // let animate = () => {
@@ -123,7 +124,7 @@ export class VisualizationSpace {
     }
 
     initControls(camera: THREE.Camera, renderer: SVGRenderer) {
-        // @ts-ignore
+        //@ts-ignore
         let controls = new OrbitControls(camera, renderer.domElement);
         controls.rotateSpeed = 1.0;
         controls.zoomSpeed = 0.8;
@@ -215,10 +216,10 @@ export class VisualizationSpace {
         // TODO
     }
 
-    
     removeMark(objectToRemove: THREE.Object3D) {
         this.scene.remove(objectToRemove);
-        //this.requestRenderScene();
+        this.requestRenderScene();
+
     }
 
     toString() : string {

--- a/src/visualization-space.ts
+++ b/src/visualization-space.ts
@@ -2,14 +2,13 @@ import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 //import { cameraProjectionMatrix } from 'three/examples/jsm/nodes/Nodes.js';
 import { SVGRenderer } from 'three/addons/renderers/SVGRenderer.js';
-import { Renderer } from './type-utils.ts'
 
 export class VisualizationSpace {
     protected domContainer: HTMLDivElement;
     protected scene: THREE.Scene;
     protected camera: THREE.Camera;
     protected controls?: OrbitControls;
-    protected threeRenderer?: THREE.Renderer;
+    protected threeRenderer: SVGRenderer;
     protected envelopeGroup: THREE.Group;
     protected vizGroup: THREE.Group;
     protected renderRequested: boolean; 
@@ -23,6 +22,7 @@ export class VisualizationSpace {
         this.scene.add(this.vizGroup);
         this.camera = this.initCamera(this.envelopeGroup.position, true);
         this.renderRequested = false;
+        this.threeRenderer = this.initThreeRenderer();
         this.initPostDomLoadLogistics();
         // For debugging
         (window as any).vs = this;
@@ -64,7 +64,6 @@ export class VisualizationSpace {
     }
 
     initPostDomLoadLogistics() {
-        this.threeRenderer = this.initThreeRenderer('svg');
         this.controls = this.initControls(this.camera, this.threeRenderer);
         this.threeRenderScene();
         // let animate = () => {
@@ -123,7 +122,8 @@ export class VisualizationSpace {
         return camera;
     }
 
-    initControls(camera: THREE.Camera, renderer: THREE.Renderer) {
+    initControls(camera: THREE.Camera, renderer: SVGRenderer) {
+        // @ts-ignore
         let controls = new OrbitControls(camera, renderer.domElement);
         controls.rotateSpeed = 1.0;
         controls.zoomSpeed = 0.8;
@@ -134,9 +134,8 @@ export class VisualizationSpace {
         return controls;
     }
 
-    initThreeRenderer() {
+    initThreeRenderer(): SVGRenderer {
         let renderer = new SVGRenderer();
-        (renderer as THREE.WebGLRenderer).setPixelRatio(window.devicePixelRatio);
         renderer.setSize(720, 480);
         this.domContainer.appendChild(renderer.domElement);
         return renderer;

--- a/src/visualization-space.ts
+++ b/src/visualization-space.ts
@@ -1,14 +1,15 @@
 import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 //import { cameraProjectionMatrix } from 'three/examples/jsm/nodes/Nodes.js';
-import { SVGRenderer } from 'three/examples/jsm/renderers/SVGRenderer.js';
+//import { SVGRenderer } from 'three/examples/jsm/renderers/SVGRenderer.js';
 
 export class VisualizationSpace {
     protected domContainer: HTMLDivElement;
     protected scene: THREE.Scene;
     protected camera: THREE.Camera;
     protected controls?: OrbitControls;
-    protected threeRenderer: SVGRenderer
+    //protected threeRenderer: SVGRenderer
+    protected threeRenderer?: THREE.Renderer;
     protected envelopeGroup: THREE.Group;
     protected vizGroup: THREE.Group;
     protected renderRequested: boolean; 
@@ -21,7 +22,7 @@ export class VisualizationSpace {
         this.scene.add(this.envelopeGroup);
         this.scene.add(this.vizGroup);
         this.camera = this.initCamera(this.envelopeGroup.position, true);
-        this.threeRenderer = this.initThreeRenderer();
+        //this.threeRenderer = this.initThreeRenderer();
         this.renderRequested = false;
         this.initPostDomLoadLogistics();
         // For debugging
@@ -64,7 +65,7 @@ export class VisualizationSpace {
     }
 
     initPostDomLoadLogistics() {
-        //this.threeRenderer = this.initThreeRenderer();
+        this.threeRenderer = this.initThreeRenderer();
         this.controls = this.initControls(this.camera, this.threeRenderer);
         this.threeRenderScene();
         // let animate = () => {
@@ -139,7 +140,7 @@ export class VisualizationSpace {
         return camera;
     }
 
-    initControls(camera: THREE.Camera, renderer: SVGRenderer) {
+    initControls(camera: THREE.Camera, renderer: THREE.Renderer) {
         //@ts-ignore
         let controls = new OrbitControls(camera, renderer.domElement);
         controls.rotateSpeed = 1.0;
@@ -151,8 +152,17 @@ export class VisualizationSpace {
         return controls;
     }
 
+    /*
     initThreeRenderer(): SVGRenderer {
         let renderer = new SVGRenderer();
+        renderer.setSize(720, 480);
+        this.domContainer.appendChild(renderer.domElement);
+        return renderer;
+    }*/
+
+    initThreeRenderer() {
+        let renderer = new THREE.WebGLRenderer({ antialias: true });
+        renderer.setPixelRatio(window.devicePixelRatio);
         renderer.setSize(720, 480);
         this.domContainer.appendChild(renderer.domElement);
         return renderer;


### PR DESCRIPTION
Because we want to be sending SVGs to the projector, I removed the WebGL renderer and raster-based screenshotting. However, now we need to make sure rendering lines is fast because the SVG renderer is much slower.